### PR TITLE
Change title to content and removed prisma.js

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -28,7 +28,7 @@
 		<h3>New Article</h3>
 		<label for="title"> Title </label>
 		<input type="text" id="title" name="title" />
-		<label for="title"> Title </label>
+		<label for="content"> Content </label>
 		<textarea id="content" name="content" rows={5} />
 		<button type="submit">Add Article</button>
 	</form>


### PR DESCRIPTION
I removed the src/lib/server/prisma.js — for some reason it was being loaded instead of the prisma.ts file; which then meant no global prisma variable was available.

Also, I just changed _title_ to _**content**_ on the form's second label.